### PR TITLE
Refactor Key type and retrieve public key support

### DIFF
--- a/OmiseSwift.xcodeproj/project.pbxproj
+++ b/OmiseSwift.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		8A50C50A1E2E250800EC9407 /* SingletonRetrievable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22338DAF1D211D7E00811363 /* SingletonRetrievable.swift */; };
 		8A50C50B1E2E250800EC9407 /* Updatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 225C4E4C1D223FF700A62F2C /* Updatable.swift */; };
 		8A50C50D1E2E259600EC9407 /* Ordering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A0F9951D22372400CA3D35 /* Ordering.swift */; };
+		8A6079301EB1E395005684CC /* Key.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A60792F1EB1E395005684CC /* Key.swift */; };
+		8A6079311EB1E395005684CC /* Key.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A60792F1EB1E395005684CC /* Key.swift */; };
 		8A634A0D1DAF916200C4D9AE /* OmisePinning.der in Resources */ = {isa = PBXBuildFile; fileRef = 8A634A0C1DAF916200C4D9AE /* OmisePinning.der */; };
 		8A634A0E1DAF916200C4D9AE /* OmisePinning.der in Resources */ = {isa = PBXBuildFile; fileRef = 8A634A0C1DAF916200C4D9AE /* OmisePinning.der */; };
 		8A7CBA501DE59F0200F83D21 /* LastDigitsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7CBA4E1DE59F0200F83D21 /* LastDigitsTest.swift */; };
@@ -221,6 +223,7 @@
 		8A3B90141E360AD30074D6CD /* Token.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
 		8A4224AA1E4C8F8E00B11AF2 /* Search.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Search.swift; sourceTree = "<group>"; };
 		8A56D41A1D78172D00F30D88 /* Currency.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Currency.swift; sourceTree = "<group>"; };
+		8A60792F1EB1E395005684CC /* Key.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Key.swift; sourceTree = "<group>"; };
 		8A634A0C1DAF916200C4D9AE /* OmisePinning.der */ = {isa = PBXFileReference; lastKnownFileType = file; path = OmisePinning.der; sourceTree = "<group>"; };
 		8A7CBA481DE59A4700F83D21 /* LastDigits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LastDigits.swift; sourceTree = "<group>"; };
 		8A7CBA4B1DE59C2000F83D21 /* LastDigitsConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LastDigitsConverter.swift; sourceTree = "<group>"; };
@@ -431,8 +434,8 @@
 			children = (
 				8ACD57391E2E563800FEE5A0 /* Account.swift */,
 				8ACD573C1E2E570600FEE5A0 /* Balance.swift */,
-				8ACB413D1E27A3F4001793CD /* BankAccount.swift */,
 				8A2BCABD1E5C039B0069577B /* Bank.swift */,
+				8ACB413D1E27A3F4001793CD /* BankAccount.swift */,
 				8ACB412C1E2793D4001793CD /* Card.swift */,
 				8ACB41141E277B60001793CD /* Charge.swift */,
 				8A56D41A1D78172D00F30D88 /* Currency.swift */,
@@ -440,6 +443,7 @@
 				8ACB41241E278837001793CD /* DetailProperty.swift */,
 				8ACB41361E279CED001793CD /* Dispute.swift */,
 				22338DB71D21392A00811363 /* Failable.swift */,
+				8A60792F1EB1E395005684CC /* Key.swift */,
 				8A7CBA481DE59A4700F83D21 /* LastDigits.swift */,
 				8A028B371E2CBABF0008E010 /* Link.swift */,
 				8A3938E51D8174C9007750AA /* List.swift */,
@@ -662,6 +666,7 @@
 				8ACD573B1E2E563800FEE5A0 /* Account.swift in Sources */,
 				8A50C5051E2E250800EC9407 /* Creatable.swift in Sources */,
 				8A28BB411E28DCE200EEBD55 /* Payment.swift in Sources */,
+				8A6079311EB1E395005684CC /* Key.swift in Sources */,
 				8ACB41641E28A403001793CD /* Endpoint.swift in Sources */,
 				8A028B391E2CC3920008E010 /* Card.swift in Sources */,
 				8A4224AC1E4C8F8E00B11AF2 /* Search.swift in Sources */,
@@ -721,6 +726,7 @@
 				8ACD573A1E2E563800FEE5A0 /* Account.swift in Sources */,
 				8ACD57221E2E3A9600FEE5A0 /* APIEndpoint.swift in Sources */,
 				8ACD57331E2E3A9600FEE5A0 /* DetailProperty.swift in Sources */,
+				8A6079301EB1E395005684CC /* Key.swift in Sources */,
 				8ACD570B1E2E3A9600FEE5A0 /* ListProperty.swift in Sources */,
 				8ACD57381E2E3A9600FEE5A0 /* ChargeEndpoint.swift in Sources */,
 				8A4224AB1E4C8F8E00B11AF2 /* Search.swift in Sources */,

--- a/OmiseSwift.xcodeproj/project.pbxproj
+++ b/OmiseSwift.xcodeproj/project.pbxproj
@@ -135,6 +135,8 @@
 		8AD3F2D61DEC113200F68FB4 /* LinkOperationFixtureTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD3F2D41DEC113200F68FB4 /* LinkOperationFixtureTest.swift */; };
 		8AE84C471E2F6A1300A3BD56 /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE84C461E2F6A1300A3BD56 /* SearchResult.swift */; };
 		8AE84C481E2F6A1300A3BD56 /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE84C461E2F6A1300A3BD56 /* SearchResult.swift */; };
+		8AEA41611EADE4C0000A5E28 /* TokenOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEA41601EADE4C0000A5E28 /* TokenOperationTest.swift */; };
+		8AEA41621EADE4C0000A5E28 /* TokenOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEA41601EADE4C0000A5E28 /* TokenOperationTest.swift */; };
 		8AEDE7D51DDC701600DD9DF1 /* Fixtures in Resources */ = {isa = PBXBuildFile; fileRef = 229873591CCE0B5A00970F8C /* Fixtures */; };
 		8AF584421E0153AC00D7D647 /* ChargeOperationsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF584411E0153AC00D7D647 /* ChargeOperationsTest.swift */; };
 		8AF9D8011E2C8E7000F10869 /* PaymentConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A075A391DF01AA7009143A9 /* PaymentConverter.swift */; };
@@ -244,6 +246,7 @@
 		8AD3F2D11DEC077000F68FB4 /* LinkOperationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkOperationTest.swift; sourceTree = "<group>"; };
 		8AD3F2D41DEC113200F68FB4 /* LinkOperationFixtureTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkOperationFixtureTest.swift; sourceTree = "<group>"; };
 		8AE84C461E2F6A1300A3BD56 /* SearchResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchResult.swift; sourceTree = "<group>"; };
+		8AEA41601EADE4C0000A5E28 /* TokenOperationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenOperationTest.swift; sourceTree = "<group>"; };
 		8AF5843E1E0152DC00D7D647 /* CurrencyFieldConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CurrencyFieldConverter.swift; sourceTree = "<group>"; };
 		8AF584411E0153AC00D7D647 /* ChargeOperationsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChargeOperationsTest.swift; sourceTree = "<group>"; };
 		98256FF11D225E3000F91436 /* TransferOperationsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransferOperationsTest.swift; sourceTree = "<group>"; };
@@ -354,12 +357,12 @@
 		2270E3AB1CC78D4200F18814 /* OmiseSwiftTests */ = {
 			isa = PBXGroup;
 			children = (
-				8A028B3F1E2CCD2D0008E010 /* New Tests */,
 				2270E3C41CC78DDB00F18814 /* Info-iOS.plist */,
 				2270E3AE1CC78D4200F18814 /* Info-OSX.plist */,
 				22112D081CC7910700D0DB54 /* ConfigTest.swift */,
 				8A07D2F31D73F5040030B68D /* FixtureClient.swift */,
 				8A07D2F61D73F8370030B68D /* FixtureTestCase.swift */,
+				229873391CCDF8B200970F8C /* JSONTest.swift */,
 				22BF9B9E1CD1F76100CD3CAD /* LiveTest.swift */,
 				22112D091CC7910700D0DB54 /* OmiseTestCase.swift */,
 				229873751CCE29D700970F8C /* OperationTest.swift */,
@@ -397,14 +400,6 @@
 			name = API;
 			sourceTree = "<group>";
 		};
-		8A028B3F1E2CCD2D0008E010 /* New Tests */ = {
-			isa = PBXGroup;
-			children = (
-				229873391CCDF8B200970F8C /* JSONTest.swift */,
-			);
-			name = "New Tests";
-			sourceTree = "<group>";
-		};
 		8A07D2FC1D742B4F0030B68D /* Fixture Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -422,10 +417,11 @@
 			isa = PBXGroup;
 			children = (
 				8AF584411E0153AC00D7D647 /* ChargeOperationsTest.swift */,
-				8A82A7091D795DCC00A198A3 /* SearchOperationTest.swift */,
-				98256FF11D225E3000F91436 /* TransferOperationsTest.swift */,
 				8AD3F2D11DEC077000F68FB4 /* LinkOperationTest.swift */,
 				8A2BCAC31E5C400F0069577B /* RecipientOperationTest.swift */,
+				8A82A7091D795DCC00A198A3 /* SearchOperationTest.swift */,
+				8AEA41601EADE4C0000A5E28 /* TokenOperationTest.swift */,
+				98256FF11D225E3000F91436 /* TransferOperationsTest.swift */,
 			);
 			name = "Live Tests";
 			sourceTree = "<group>";
@@ -766,6 +762,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2298733B1CCDF99700970F8C /* JSONTest.swift in Sources */,
+				8AEA41621EADE4C0000A5E28 /* TokenOperationTest.swift in Sources */,
 				8A028B401E2CCE550008E010 /* OmiseTestCase.swift in Sources */,
 				8A2BCAC51E5C400F0069577B /* RecipientOperationTest.swift in Sources */,
 			);
@@ -782,6 +779,7 @@
 				22BF9BA11CD1F76900CD3CAD /* LiveTest.swift in Sources */,
 				8AF584421E0153AC00D7D647 /* ChargeOperationsTest.swift in Sources */,
 				8A2698A31D743A2100515A0A /* RefundOperationFixtureTests.swift in Sources */,
+				8AEA41611EADE4C0000A5E28 /* TokenOperationTest.swift in Sources */,
 				8A7CBA501DE59F0200F83D21 /* LastDigitsTest.swift in Sources */,
 				22112D0B1CC7910700D0DB54 /* ConfigTest.swift in Sources */,
 				229873881CCF566F00970F8C /* RequestTest.swift in Sources */,

--- a/OmiseSwift.xcodeproj/project.pbxproj
+++ b/OmiseSwift.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		8A50C50D1E2E259600EC9407 /* Ordering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A0F9951D22372400CA3D35 /* Ordering.swift */; };
 		8A6079301EB1E395005684CC /* Key.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A60792F1EB1E395005684CC /* Key.swift */; };
 		8A6079311EB1E395005684CC /* Key.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A60792F1EB1E395005684CC /* Key.swift */; };
+		8A6079361EB2033B005684CC /* PublicKeyEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6079351EB2033B005684CC /* PublicKeyEndpoint.swift */; };
+		8A6079371EB2033B005684CC /* PublicKeyEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6079351EB2033B005684CC /* PublicKeyEndpoint.swift */; };
 		8A634A0D1DAF916200C4D9AE /* OmisePinning.der in Resources */ = {isa = PBXBuildFile; fileRef = 8A634A0C1DAF916200C4D9AE /* OmisePinning.der */; };
 		8A634A0E1DAF916200C4D9AE /* OmisePinning.der in Resources */ = {isa = PBXBuildFile; fileRef = 8A634A0C1DAF916200C4D9AE /* OmisePinning.der */; };
 		8A7CBA501DE59F0200F83D21 /* LastDigitsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7CBA4E1DE59F0200F83D21 /* LastDigitsTest.swift */; };
@@ -224,6 +226,7 @@
 		8A4224AA1E4C8F8E00B11AF2 /* Search.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Search.swift; sourceTree = "<group>"; };
 		8A56D41A1D78172D00F30D88 /* Currency.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Currency.swift; sourceTree = "<group>"; };
 		8A60792F1EB1E395005684CC /* Key.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Key.swift; sourceTree = "<group>"; };
+		8A6079351EB2033B005684CC /* PublicKeyEndpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PublicKeyEndpoint.swift; sourceTree = "<group>"; };
 		8A634A0C1DAF916200C4D9AE /* OmisePinning.der */ = {isa = PBXFileReference; lastKnownFileType = file; path = OmisePinning.der; sourceTree = "<group>"; };
 		8A7CBA481DE59A4700F83D21 /* LastDigits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LastDigits.swift; sourceTree = "<group>"; };
 		8A7CBA4B1DE59C2000F83D21 /* LastDigitsConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LastDigitsConverter.swift; sourceTree = "<group>"; };
@@ -349,6 +352,7 @@
 				22A0F98C1D2160F900CA3D35 /* Creatable.swift */,
 				225C4E4E1D22412A00A62F2C /* Destroyable.swift */,
 				22A0F9861D21580400CA3D35 /* Listable.swift */,
+				8A6079351EB2033B005684CC /* PublicKeyEndpoint.swift */,
 				22A0F9881D215D3700CA3D35 /* Retrievable.swift */,
 				8A82A7061D7942E800A198A3 /* Searchable.swift */,
 				22338DAF1D211D7E00811363 /* SingletonRetrievable.swift */,
@@ -680,6 +684,7 @@
 				8A28BB441E290A5500EEBD55 /* DateConverter.swift in Sources */,
 				8ACB41501E28A3C2001793CD /* Charge.swift in Sources */,
 				8A061A9F1E2E307D0025EC14 /* DateComponentsConverter.swift in Sources */,
+				8A6079371EB2033B005684CC /* PublicKeyEndpoint.swift in Sources */,
 				8AF9D8031E2C942A00F10869 /* EnumConverter.swift in Sources */,
 				8ACB415A1E28A3C2001793CD /* Recipient.swift in Sources */,
 				8A50C5091E2E250800EC9407 /* Searchable.swift in Sources */,
@@ -740,6 +745,7 @@
 				8ACD571C1E2E3A9600FEE5A0 /* Endpoint.swift in Sources */,
 				8ACD57151E2E3A9600FEE5A0 /* Currency.swift in Sources */,
 				8ACD57281E2E3A9600FEE5A0 /* EnumConverter.swift in Sources */,
+				8A6079361EB2033B005684CC /* PublicKeyEndpoint.swift in Sources */,
 				8ACD572A1E2E3A9600FEE5A0 /* Searchable.swift in Sources */,
 				8ACD57351E2E3A9600FEE5A0 /* ResourceInfo.swift in Sources */,
 				8ACD570F1E2E3A9600FEE5A0 /* APIError.swift in Sources */,

--- a/OmiseSwift/APIClient.swift
+++ b/OmiseSwift/APIClient.swift
@@ -36,14 +36,15 @@ public class APIClient: NSObject {
     func preferredKeyForServerEndpoint(_ endpoint: ServerEndpoint) -> String {
         switch endpoint {
         case .api:
-            return config.secretKey + ":X"
+            return config.secretKey
         case .vault:
             return config.publicKey
         }
     }
     
     func preferredEncodedKeyForServerEndpoint(_ endpoint: ServerEndpoint) throws -> String {
-        let data = preferredKeyForServerEndpoint(endpoint).data(using: .utf8, allowLossyConversion: false)
+        // We append `:X` to the key as a workaround, as some parser would fail if they can't parse the password part.
+        let data = (preferredKeyForServerEndpoint(endpoint) + ":X").data(using: .utf8, allowLossyConversion: false)
         
         guard let encodedKey = data?.base64EncodedString(options: .lineLength64Characters) else {
             throw OmiseError.configuration("bad API key (encoding failed.)")

--- a/OmiseSwift/APIClient.swift
+++ b/OmiseSwift/APIClient.swift
@@ -36,10 +36,20 @@ public class APIClient: NSObject {
     func preferredKeyForServerEndpoint(_ endpoint: ServerEndpoint) -> String {
         switch endpoint {
         case .api:
-            return config.secretKey
+            return config.secretKey + ":X"
         case .vault:
             return config.publicKey
         }
+    }
+    
+    func preferredEncodedKeyForServerEndpoint(_ endpoint: ServerEndpoint) throws -> String {
+        let data = preferredKeyForServerEndpoint(endpoint).data(using: .utf8, allowLossyConversion: false)
+        
+        guard let encodedKey = data?.base64EncodedString(options: .lineLength64Characters) else {
+            throw OmiseError.configuration("bad API key (encoding failed.)")
+        }
+        
+        return "Basic \(encodedKey)"
     }
     
     @discardableResult

--- a/OmiseSwift/APIClient.swift
+++ b/OmiseSwift/APIClient.swift
@@ -36,9 +36,9 @@ public class APIClient: NSObject {
     func preferredKeyForServerEndpoint(_ endpoint: ServerEndpoint) -> String {
         switch endpoint {
         case .api:
-            return config.secretKey
-        case .vault:
-            return config.publicKey
+            return config.applicationKey.key
+        case .vault(let publicKey):
+            return publicKey.key
         }
     }
     

--- a/OmiseSwift/APIConfiguration.swift
+++ b/OmiseSwift/APIConfiguration.swift
@@ -3,12 +3,10 @@ import Foundation
 
 public struct APIConfiguration {
     public let apiVersion: String = "2015-11-17"
-    public let publicKey: String
-    public let secretKey: String
+    public let applicationKey: Key<ApplicationKey>
     
-    public init(publicKey: String, secretKey: String) {
-        self.publicKey = publicKey
-        self.secretKey = secretKey
+    public init(applicationKey: Key<ApplicationKey>) {
+        self.applicationKey = applicationKey
     }
 }
 

--- a/OmiseSwift/APIEndpoint.swift
+++ b/OmiseSwift/APIEndpoint.swift
@@ -11,6 +11,12 @@ public struct APIEndpoint<DataType: OmiseObject> {
     public let pathComponents: [String]
     public let params: APIParams?
     
+    init(endpoint: ServerEndpoint = .api, method: String, pathComponents: [String], params: APIParams?) {
+        self.endpoint = endpoint
+        self.method = method
+        self.pathComponents = pathComponents
+        self.params = params
+    }
     
     func makeURL() -> URL {
         let url = endpoint.url(withComponents: pathComponents)

--- a/OmiseSwift/APIRequest.swift
+++ b/OmiseSwift/APIRequest.swift
@@ -82,8 +82,7 @@ public class APIRequest<Result: OmiseObject> {
     func makeURLRequest() throws -> URLRequest {
         let requestURL = endpoint.makeURL()
         
-        let apiKey = client.preferredKeyForServerEndpoint(endpoint.endpoint)
-        let auth = try APIRequest.encodeAuthorizationHeader(withAPIKey: apiKey)
+        let auth = try client.preferredEncodedKeyForServerEndpoint(endpoint.endpoint)
         
         var request = URLRequest(url: requestURL)
         request.httpMethod = endpoint.method
@@ -100,15 +99,5 @@ public class APIRequest<Result: OmiseObject> {
         request.httpBody = payload
         return request as URLRequest
     }
-    
-    static func encodeAuthorizationHeader(withAPIKey apiKey: String) throws -> String {
-        let data = "\(apiKey):X".data(using: String.Encoding.utf8)
-        guard let md5 = data?.base64EncodedString(options: .lineLength64Characters) else {
-            throw OmiseError.configuration("bad API key (encoding failed.)")
-        }
-        
-        return "Basic \(md5)"
-    }
-    
 }
 

--- a/OmiseSwift/ChargeEndpoint.swift
+++ b/OmiseSwift/ChargeEndpoint.swift
@@ -9,7 +9,6 @@ extension Charge {
     
     public static func captureEndpointWithID(_ id: String) -> CaptureEndpoint {
         return CaptureEndpoint(
-            endpoint: resourceInfo.endpoint,
             method: "POST",
             pathComponents: [resourceInfo.path, id, "capture"],
             params: nil
@@ -23,7 +22,6 @@ extension Charge {
     
     public static func reverseEndpointWithID(_ id: String) -> ReverseEndpoint {
         return ReverseEndpoint(
-            endpoint: resourceInfo.endpoint,
             method: "POST",
             pathComponents: [resourceInfo.path, id, "reverse"],
             params: nil

--- a/OmiseSwift/Creatable.swift
+++ b/OmiseSwift/Creatable.swift
@@ -10,7 +10,6 @@ public extension Creatable where Self: OmiseLocatableObject {
     
     public static func createEndpointWith(parent: OmiseResourceObject?, params: CreateParams) -> CreateEndpoint {
         return CreateEndpoint(
-            endpoint: resourceInfo.endpoint,
             method: "POST",
             pathComponents: Self.makeResourcePathsWithParent(parent),
             params: params

--- a/OmiseSwift/Destroyable.swift
+++ b/OmiseSwift/Destroyable.swift
@@ -26,7 +26,6 @@ public extension Destroyable where Self: OmiseResourceObject {
     
     public static func destroyEndpointWith(parent: OmiseResourceObject?, id: String) -> DestroyEndpoint {
         return DestroyEndpoint(
-            endpoint: resourceInfo.endpoint,
             method: "DELETE",
             pathComponents: Self.makeResourcePathsWithParent(parent, id: id),
             params: nil

--- a/OmiseSwift/Dispute.swift
+++ b/OmiseSwift/Dispute.swift
@@ -117,7 +117,6 @@ extension Dispute: Searchable {
 extension Dispute {
     public static func list(using client: APIClient, state: DisputeStatusQuery, params: ListParams? = nil, callback: @escaping Dispute.ListRequest.Callback) -> Dispute.ListRequest? {
         let endpoint = ListEndpoint(
-            endpoint: resourceInfo.endpoint,
             method: "GET",
             pathComponents: [resourceInfo.path, state.rawValue],
             params: nil

--- a/OmiseSwift/Endpoint.swift
+++ b/OmiseSwift/Endpoint.swift
@@ -1,11 +1,21 @@
 import Foundation
 
-public enum ServerEndpoint: String {
-    case vault = "https://vault.omise.co"
-    case api = "https://api.omise.co"
+let stagingURLSuffix = "-staging.omise.co"
+let productionURLSuffix = ".omise.co"
+
+public enum ServerEndpoint {
+    case vault(Key<PublicKey>)
+    case api
     
     var url: URL {
-        return URL(string: rawValue)!
+        let urlString: String
+        switch self {
+        case .vault:
+            urlString = "https://vault" + productionURLSuffix
+        case .api:
+            urlString = "https://api" + productionURLSuffix
+        }
+        return URL(string: urlString)!
     }
     
     func url(withComponents components: [String]) -> URL {

--- a/OmiseSwift/Key.swift
+++ b/OmiseSwift/Key.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+public protocol KeyKind {
+    static var prefix: String { get }
+    static var kind: String { get }
+}
+
+public enum ApplicationKey: KeyKind {
+    public static let prefix: String = "akey"
+    public static let kind: String = "application"
+}
+
+public enum PublicKey: KeyKind {
+    public static let prefix: String = "pkey"
+    public static let kind: String = "public"
+}
+
+
+public struct Key<Kind: KeyKind>: OmiseIdentifiableObject, OmiseLiveModeObject {
+    public let id: String
+    public let object: String
+    public let isLive: Bool
+    public let createdDate: Date
+    
+    public let key: String
+    public let name: String?
+    
+    public init?(JSON json: Any) {
+        guard let json = json as? [String: Any],
+            let omiseProperties = Key.parseOmiseProperties(JSON: json),
+            let key = json["key"] as? String,
+            let kind = json["kind"] as? String,
+            Kind.kind == kind, key.hasPrefix(Kind.prefix) else {
+                return nil
+                
+        }
+        
+        (self.object, self.isLive, self.id, self.createdDate) = omiseProperties
+        self.key = key
+        self.name = json["name"] as? String
+    }
+}

--- a/OmiseSwift/Key.swift
+++ b/OmiseSwift/Key.swift
@@ -32,7 +32,6 @@ public struct Key<Kind: KeyKind>: OmiseIdentifiableObject, OmiseLiveModeObject {
             let kind = json["kind"] as? String,
             Kind.kind == kind, key.hasPrefix(Kind.prefix) else {
                 return nil
-                
         }
         
         (self.object, self.isLive, self.id, self.createdDate) = omiseProperties

--- a/OmiseSwift/Listable.swift
+++ b/OmiseSwift/Listable.swift
@@ -36,7 +36,6 @@ public extension Listable where Self: OmiseLocatableObject {
     @discardableResult
     public static func listEndpointWith(parent: OmiseResourceObject?, params: ListParams?) -> ListEndpoint {
         return ListEndpoint(
-            endpoint: resourceInfo.endpoint,
             method: "GET",
             pathComponents: makeResourcePathsWithParent(parent),
             params: params

--- a/OmiseSwift/Object.swift
+++ b/OmiseSwift/Object.swift
@@ -105,6 +105,21 @@ extension OmiseIdentifiableObject {
     }
 }
 
+extension OmiseLiveModeObject where Self: OmiseIdentifiableObject {
+    static func parseOmiseProperties(JSON json: Any) -> (object: String, isLiveMode: Bool, id: String, createdDate: Date)? {
+        guard let json = json as? [String: Any],
+            let object = Self.parseObject(JSON: json),
+            let isLiveMode = json["livemode"] as? Bool,
+            let id = json["id"] as? String,
+            let created = json["created"].flatMap(parseDate) else {
+                return nil
+        }
+        
+        return (object: object, isLiveMode: isLiveMode, id: id, createdDate: created)
+    }
+}
+
+
 extension OmiseLocatableObject where Self: OmiseIdentifiableObject {
     static func parseOmiseProperties(JSON json: Any) -> (object: String, location: String, id: String, createdDate: Date)? {
         guard let json = json as? [String: Any],

--- a/OmiseSwift/PublicKeyEndpoint.swift
+++ b/OmiseSwift/PublicKeyEndpoint.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public extension Key where Kind == PublicKey {
+    public typealias PublicKeyRetrieveEndpoint = APIEndpoint<Key<PublicKey>>
+    public typealias PublicKeyRetrieveRequest = APIRequest<Key<PublicKey>>
+    
+    
+    public static func retrivePublicKeyEndpoint() -> PublicKeyRetrieveEndpoint {
+        return APIEndpoint(
+            method: "GET", pathComponents: ["keys", "public"], params: nil
+        )
+    }
+    
+    public static func retrievePublicKeyUsingClient(_ client: APIClient, callback: PublicKeyRetrieveRequest.Callback?) -> PublicKeyRetrieveRequest? {
+        let endpoint = self.retrivePublicKeyEndpoint()
+        return client.requestToEndpoint(endpoint, callback: callback)
+    }
+}
+

--- a/OmiseSwift/ResourceInfo.swift
+++ b/OmiseSwift/ResourceInfo.swift
@@ -2,12 +2,10 @@ import Foundation
 
 public struct ResourceInfo {
     let parentType: OmiseResourceObject.Type?
-    let endpoint: ServerEndpoint
     let path: String
     
-    public init(parentType: OmiseResourceObject.Type? = nil, endpoint: ServerEndpoint = .api, path: String) {
+    public init(parentType: OmiseResourceObject.Type? = nil, path: String) {
         self.parentType = parentType
-        self.endpoint = endpoint
         self.path = path
     }
 }

--- a/OmiseSwift/Retrievable.swift
+++ b/OmiseSwift/Retrievable.swift
@@ -19,7 +19,6 @@ public extension Retrievable where Self: OmiseLocatableObject {
     public static func retrieveEndpointWith(parent: OmiseResourceObject?, id: String) -> RetrieveEndpoint {
         let retrieveParams = RetrieveParams(isExpanded: true)
         return RetrieveEndpoint(
-            endpoint: resourceInfo.endpoint,
             method: "GET",
             pathComponents: makeResourcePathsWithParent(parent, id: id),
             params: retrieveParams

--- a/OmiseSwift/SingletonRetrievable.swift
+++ b/OmiseSwift/SingletonRetrievable.swift
@@ -8,7 +8,6 @@ public extension SingletonRetrievable where Self: OmiseLocatableObject {
     
     public static func retrieveEndpointWithParent(_ parent: OmiseResourceObject?) -> SingletonRetrieveEndpoint {
         return SingletonRetrieveEndpoint(
-            endpoint: resourceInfo.endpoint,
             method: "GET",
             pathComponents: makeResourcePathsWithParent(parent),
             params: nil

--- a/OmiseSwift/Token.swift
+++ b/OmiseSwift/Token.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public struct Token: OmiseLocatableObject, OmiseIdentifiableObject, OmiseLiveModeObject {
-    public static let resourceInfo: ResourceInfo = ResourceInfo(endpoint: .vault, path: "/tokens")
+    public static let resourceInfo: ResourceInfo = ResourceInfo(path: "/tokens")
     
     public var object: String
     public var location: String
@@ -58,7 +58,7 @@ public struct TokenParams: APIParams {
                 "security_code": securityCode,
                 "city": city as Any,
                 "postal_code": postalCode,
-            ])
+                ])
         ]
     }
     
@@ -74,6 +74,25 @@ public struct TokenParams: APIParams {
 
 extension Token: Creatable {
     public typealias CreateParams = TokenParams
+    
+    public static func createEndpointWith(parent: OmiseResourceObject?, usingKey key: Key<PublicKey>, params: CreateParams) -> CreateEndpoint {
+        return CreateEndpoint(
+            endpoint: .vault(key),
+            method: "POST",
+            pathComponents: Token.makeResourcePathsWithParent(parent),
+            params: params
+        )
+    }
+    
+    public static func create(using client: APIClient, parent: OmiseResourceObject? = nil, usingKey key: Key<PublicKey>, params: CreateParams, callback: @escaping CreateRequest.Callback) -> CreateRequest? {
+        guard Token.verifyParent(parent) else {
+            return nil
+        }
+        
+        let endpoint = self.createEndpointWith(parent: parent, usingKey: key, params: params)
+        return client.requestToEndpoint(endpoint, callback: callback)
+    }
+    
 }
 
 extension Token: Retrievable {

--- a/OmiseSwift/Updatable.swift
+++ b/OmiseSwift/Updatable.swift
@@ -10,7 +10,6 @@ public extension Updatable where Self: OmiseResourceObject {
     
     public static func updateEndpointWith(parent: OmiseResourceObject?, id: String, params: UpdateParams) -> UpdateEndpoint {
         return UpdateEndpoint(
-            endpoint: resourceInfo.endpoint,
             method: "PATCH",
             pathComponents: makeResourcePathsWithParent(parent, id: id),
             params: params

--- a/OmiseSwiftTests/ChargeOperationsTest.swift
+++ b/OmiseSwiftTests/ChargeOperationsTest.swift
@@ -2,15 +2,7 @@ import Foundation
 import XCTest
 @testable import Omise
 
-class ChargeOperationsTest: OmiseTestCase {
-    var testClient: APIClient {
-        let config = APIConfiguration(
-            publicKey: "pkey_test_54oojsyhv5uq1kzf4g4",
-            secretKey: "skey_test_54oojsyhuzzr51wa5hc"
-        )
-        
-        return APIClient(config: config)
-    }
+class ChargeOperationsTest: LiveTest {
     
     func testChargeList() {
         let expectation = self.expectation(description: "charge list")

--- a/OmiseSwiftTests/ConfigTest.swift
+++ b/OmiseSwiftTests/ConfigTest.swift
@@ -3,12 +3,5 @@ import XCTest
 @testable import Omise
 
 class ConfigTest: OmiseTestCase {
-    func testCtor() {
-        let config = APIConfiguration(
-            publicKey: "789",
-            secretKey: "789")
-        XCTAssertEqual("789", config.secretKey)
-        XCTAssertNil(config.publicKey)
-        XCTAssertNil(config.apiVersion)
-    }
+    
 }

--- a/OmiseSwiftTests/FixtureTestCase.swift
+++ b/OmiseSwiftTests/FixtureTestCase.swift
@@ -3,11 +3,31 @@ import XCTest
 
 class FixtureTestCase: OmiseTestCase {
     var testClient: FixtureClient {
-        let config = APIConfiguration(
-            publicKey: "pkey_test_5511txgnw3t6tqqlf0v",
-            secretKey: "skey_test_5511tympbgf8im3jhjv"
-        )
-        
+        let testingApplicationKeyJSON = [
+            "kind": "application",
+            "name": "iOS Test Case",
+            "object": "key",
+            "key": "akey_test_57rqqo973wulbfhpqgq",
+            "id": "key_test_57rqqo999mo107dacao",
+            "livemode": false,
+            "created": "2017-04-26T12:06:34Z"
+            ] as [String : Any]
+        let config = APIConfiguration(applicationKey: Key<ApplicationKey>(JSON: testingApplicationKeyJSON)!)
         return FixtureClient(config: config)
+    }
+    
+    func fixturesData(for filename: String) -> Data? {
+        let bundle = Bundle(for: OmiseTestCase.self)
+        guard let path = bundle.path(forResource: filename, ofType: "json") else {
+            XCTFail("could not load fixtures.")
+            return nil
+        }
+        
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
+            XCTFail("could not load fixtures at path: \(path)")
+            return nil
+        }
+        
+        return data
     }
 }

--- a/OmiseSwiftTests/LinkOperationTest.swift
+++ b/OmiseSwiftTests/LinkOperationTest.swift
@@ -2,15 +2,7 @@ import XCTest
 import Omise
 
 
-class LinkOperationTest: OmiseTestCase {
-    var testClient: APIClient {
-        let config = APIConfiguration(
-            publicKey: "pkey_test_54oojsyhv5uq1kzf4g4",
-            secretKey: "skey_test_54oojsyhuzzr51wa5hc"
-        )
-    
-        return APIClient(config: config)
-    }
+class LinkOperationTest: LiveTest {
     
     func testLinkRetrieve() {
         let expectation = self.expectation(description: "link result")

--- a/OmiseSwiftTests/LiveTest.swift
+++ b/OmiseSwiftTests/LiveTest.swift
@@ -4,11 +4,16 @@ import Omise
 
 class LiveTest: OmiseTestCase {
     var testClient: APIClient {
-        let config = APIConfiguration(
-            publicKey: "pkey_test_52d6po3fvio2w6tefpb",
-            secretKey: "skey_test_52d6ppdms4p1jhnkigq"
-        )
-        
+        let testingApplicationKeyJSON = [
+            "kind": "application",
+            "name": "iOS Test Case",
+            "object": "key",
+            "key": "akey_test_57rqqo973wulbfhpqgq",
+            "id": "key_test_57rqqo999mo107dacao",
+            "livemode": false,
+            "created": "2017-04-26T12:06:34Z"
+            ] as [String : Any]
+        let config = APIConfiguration(applicationKey: Key<ApplicationKey>(JSON: testingApplicationKeyJSON)!)
         return APIClient(config: config)
     }
     

--- a/OmiseSwiftTests/OmiseTestCase.swift
+++ b/OmiseSwiftTests/OmiseTestCase.swift
@@ -1,18 +1,7 @@
 import XCTest
+import Omise
+
 
 class OmiseTestCase: XCTestCase {
-    func fixturesData(for filename: String) -> Data? {
-        let bundle = Bundle(for: OmiseTestCase.self)
-        guard let path = bundle.path(forResource: filename, ofType: "json") else {
-            XCTFail("could not load fixtures.")
-            return nil
-        }
-        
-        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
-            XCTFail("could not load fixtures at path: \(path)")
-            return nil
-        }
-        
-        return data
-    }
+
 }

--- a/OmiseSwiftTests/RecipientOperationTest.swift
+++ b/OmiseSwiftTests/RecipientOperationTest.swift
@@ -2,15 +2,7 @@ import Foundation
 import XCTest
 @testable import Omise
 
-class RecipientOperationTest: OmiseTestCase {
-    var testClient: APIClient = {
-        let config = APIConfiguration(
-            publicKey: "<#Public Key#>",
-            secretKey: "<#Secret Key#>"
-        )
-        
-        return APIClient(config: config)
-    }()
+class RecipientOperationTest: LiveTest {
     
     func testRecipientList() {
         let expectation = self.expectation(description: "recipient list")

--- a/OmiseSwiftTests/RequestTest.swift
+++ b/OmiseSwiftTests/RequestTest.swift
@@ -3,9 +3,6 @@ import XCTest
 import Omise
 
 class RequestTest: OmiseTestCase {
-    let config = APIConfiguration(
-        publicKey: "pkey_test_123",
-        secretKey: "skey_test_123")
     let session = URLSession(configuration: URLSessionConfiguration.ephemeral)
     
 //    func testCtor() {

--- a/OmiseSwiftTests/SearchOperationTest.swift
+++ b/OmiseSwiftTests/SearchOperationTest.swift
@@ -1,16 +1,7 @@
 import XCTest
 @testable import Omise
 
-class SearchOperationTest: OmiseTestCase {
-    
-    var testClient: APIClient {
-        let config = APIConfiguration(
-            publicKey: "pkey_test_54oojsyhv5uq1kzf4g4",
-            secretKey: "skey_test_54oojsyhuzzr51wa5hc"
-        )
-        
-        return APIClient(config: config)
-    }
+class SearchOperationTest: LiveTest {
     
     func testSearchChargeByLastDigits() {
         let expectation = self.expectation(description: "transfer result")

--- a/OmiseSwiftTests/TokenOperationTest.swift
+++ b/OmiseSwiftTests/TokenOperationTest.swift
@@ -2,17 +2,7 @@ import Foundation
 import XCTest
 import Omise
 
-class TokenOperationTest: OmiseTestCase {
-    
-    var testClient: APIClient {
-        let config = APIConfiguration(
-            publicKey: "pkey_test_54oojsyhv5uq1kzf4g4",
-            secretKey: "skey_test_54oojsyhuzzr51wa5hc"
-        )
-        
-        return APIClient(config: config)
-    }
-    
+class TokenOperationTest: LiveTest {
     
     func testTransferCreate() {
         let expectation = self.expectation(description: "token create")
@@ -33,5 +23,5 @@ class TokenOperationTest: OmiseTestCase {
         
         waitForExpectations(timeout: 15.0, handler: nil)
     }
-
 }
+

--- a/OmiseSwiftTests/TokenOperationTest.swift
+++ b/OmiseSwiftTests/TokenOperationTest.swift
@@ -1,0 +1,37 @@
+import Foundation
+import XCTest
+import Omise
+
+class TokenOperationTest: OmiseTestCase {
+    
+    var testClient: APIClient {
+        let config = APIConfiguration(
+            publicKey: "pkey_test_54oojsyhv5uq1kzf4g4",
+            secretKey: "skey_test_54oojsyhuzzr51wa5hc"
+        )
+        
+        return APIClient(config: config)
+    }
+    
+    
+    func testTransferCreate() {
+        let expectation = self.expectation(description: "token create")
+        
+        let createParams = TokenParams(number: "4242424242424242", name: "John Appleseed", expiration: (month: 1, year: 2021), securityCode: "123")
+        
+        let request = Token.create(using: testClient, params: createParams) { (result) in
+            defer { expectation.fulfill() }
+            
+            switch result {
+            case let .success(token):
+                XCTAssertNotNil(token)
+                XCTAssertEqual(token.card.lastDigits.lastDigits, "4242")
+            case let .fail(error):
+                XCTFail("\(error)")
+            }
+        }
+        
+        waitForExpectations(timeout: 15.0, handler: nil)
+    }
+
+}

--- a/OmiseSwiftTests/TransferOperationsTest.swift
+++ b/OmiseSwiftTests/TransferOperationsTest.swift
@@ -2,16 +2,7 @@ import Foundation
 import XCTest
 import Omise
 
-class TransferOperationsTest: OmiseTestCase {
-    var testClient: APIClient {
-        let config = APIConfiguration(
-            publicKey: "pkey_test_54oojsyhv5uq1kzf4g4",
-            secretKey: "skey_test_54oojsyhuzzr51wa5hc"
-        )
-        
-        return APIClient(config: config)
-    }
-    
+class TransferOperationsTest: LiveTest {
     func testTransferRetrieve() {
         let expectation = self.expectation(description: "transfer result")
         


### PR DESCRIPTION
Since our backend has a new `keys` endpoints which are used for manage the account's keys. This PR introduces the support of the keys APIs and also refactor by adopting `Key` data type instead of just a plain String