### PR TITLE
Parse the account’s currency on Account Retrieve API

### DIFF
--- a/OmiseSwift/Account.swift
+++ b/OmiseSwift/Account.swift
@@ -9,17 +9,21 @@ public struct Account: OmiseLocatableObject, OmiseIdentifiableObject {
     public let createdDate: Date
     
     public let email: String
+    
+    public let currency: Currency
 }
 
 extension Account {
     public init?(JSON json: Any) {
         guard let json = json as? [String: Any],
             let omiseProperties = Account.parseOmiseProperties(JSON: json),
-            let email = json["email"] as? String else {
+            let email = json["email"] as? String,
+            let currency = (json["currency"] as? String).flatMap(Currency.init(code:)) else {
                 return nil
         }
         (self.object, self.location, self.id, self.createdDate) = omiseProperties
         self.email = email
+        self.currency = currency
     }
 }
 

--- a/OmiseSwift/Currency.swift
+++ b/OmiseSwift/Currency.swift
@@ -55,3 +55,11 @@ public enum Currency {
         }
     }
 }
+
+
+extension Currency: Equatable {
+    public static func ==(lhs: Currency, rhs: Currency) -> Bool {
+        return lhs.code == rhs.code
+    }
+}
+


### PR DESCRIPTION
Now our API return the account's currency with the response. This PR added a `currency` property to Account type and support for parsing it from the response