### PR TITLE
Fix leaky abstraction bug in JSONDecoder

### DIFF
--- a/OmiseSwift.xcodeproj/project.pbxproj
+++ b/OmiseSwift.xcodeproj/project.pbxproj
@@ -84,6 +84,8 @@
 		8A98759C1F0647050090D56F /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A98759A1F0647050090D56F /* Document.swift */; };
 		8A98759E1F0673C90090D56F /* DocumentOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A98759D1F0673C90090D56F /* DocumentOperationTest.swift */; };
 		8A98759F1F0673C90090D56F /* DocumentOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A98759D1F0673C90090D56F /* DocumentOperationTest.swift */; };
+		8A9B2AB41FB9B5C5002F42C7 /* DecoderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9B2AB31FB9B5C5002F42C7 /* DecoderTest.swift */; };
+		8A9B2AB51FB9B5C5002F42C7 /* DecoderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A9B2AB31FB9B5C5002F42C7 /* DecoderTest.swift */; };
 		8AA2BF241F54144F0083F8A6 /* URLQueryItemEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA2BF231F54144F0083F8A6 /* URLQueryItemEncoder.swift */; };
 		8AA2BF251F54144F0083F8A6 /* URLQueryItemEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA2BF231F54144F0083F8A6 /* URLQueryItemEncoder.swift */; };
 		8AA2EFC51D6C8A1E0052CCFB /* Omise.h in Headers */ = {isa = PBXBuildFile; fileRef = 220C32701CC762330060112E /* Omise.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -246,6 +248,7 @@
 		8A82A7091D795DCC00A198A3 /* SearchOperationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchOperationTest.swift; sourceTree = "<group>"; };
 		8A98759A1F0647050090D56F /* Document.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Document.swift; sourceTree = "<group>"; };
 		8A98759D1F0673C90090D56F /* DocumentOperationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocumentOperationTest.swift; sourceTree = "<group>"; };
+		8A9B2AB31FB9B5C5002F42C7 /* DecoderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoderTest.swift; sourceTree = "<group>"; };
 		8AA2BF231F54144F0083F8A6 /* URLQueryItemEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLQueryItemEncoder.swift; sourceTree = "<group>"; };
 		8ACB41121E277607001793CD /* Object.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Object.swift; sourceTree = "<group>"; };
 		8ACB41141E277B60001793CD /* Charge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Charge.swift; sourceTree = "<group>"; };
@@ -383,6 +386,7 @@
 			children = (
 				8A1CF6AF1F8BC1BD003EDB38 /* LastDigitsTest.swift */,
 				229873801CCF3B1900970F8C /* URLEncoderTest.swift */,
+				8A9B2AB31FB9B5C5002F42C7 /* DecoderTest.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -792,6 +796,7 @@
 				8A98759F1F0673C90090D56F /* DocumentOperationTest.swift in Sources */,
 				8A5880F01F46EEB300647405 /* ReceiptsOperationFixtureTests.swift in Sources */,
 				8A2BCAC51E5C400F0069577B /* RecipientOperationTest.swift in Sources */,
+				8A9B2AB51FB9B5C5002F42C7 /* DecoderTest.swift in Sources */,
 				8A1CF6B11F8BC1D8003EDB38 /* LastDigitsTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -808,6 +813,7 @@
 				22BF9BA11CD1F76900CD3CAD /* LiveTest.swift in Sources */,
 				8AF584421E0153AC00D7D647 /* ChargeOperationsTest.swift in Sources */,
 				8A2698A31D743A2100515A0A /* RefundOperationFixtureTests.swift in Sources */,
+				8A9B2AB41FB9B5C5002F42C7 /* DecoderTest.swift in Sources */,
 				8AEA41611EADE4C0000A5E28 /* TokenOperationTest.swift in Sources */,
 				8A1039651EDD5FD70035B2EF /* ScheduleOperationsTest.swift in Sources */,
 				8ACBB54C1ED8277100F1DA36 /* URLEncoderTest.swift in Sources */,

--- a/OmiseSwift/Tool.swift
+++ b/OmiseSwift/Tool.swift
@@ -237,12 +237,12 @@ extension KeyedDecodingContainerProtocol {
         var dictionary = Dictionary<String, Any>()
         
         for key in allKeys {
-            if let intValue = try? decode(Int.self, forKey: key) {
-                dictionary[key.stringValue] = intValue
+            if let boolValue = try? decode(Bool.self, forKey: key) {
+                dictionary[key.stringValue] = boolValue
             } else if let stringValue = try? decode(String.self, forKey: key) {
                 dictionary[key.stringValue] = stringValue
-            } else if let boolValue = try? decode(Bool.self, forKey: key) {
-                dictionary[key.stringValue] = boolValue
+            } else if let intValue = try? decode(Int.self, forKey: key) {
+                dictionary[key.stringValue] = intValue
             } else if let doubleValue = try? decode(Double.self, forKey: key) {
                 dictionary[key.stringValue] = doubleValue
             } else if let nestedDictionary = try? decode(Dictionary<String, Any>.self, forKey: key) {
@@ -314,9 +314,9 @@ extension KeyedEncodingContainerProtocol where Key == JSONCodingKeys {
         try value.forEach({ (key, value) in
             let key = JSONCodingKeys(key: key)
             switch value {
-            case let value as Int:
-                try encode(value, forKey: key)
             case let value as Bool:
+                try encode(value, forKey: key)
+            case let value as Int:
                 try encode(value, forKey: key)
             case let value as String:
                 try encode(value, forKey: key)
@@ -363,9 +363,9 @@ extension UnkeyedEncodingContainer {
     mutating func encodeJSONArray(_ value: Array<Any>) throws {
         try value.enumerated().forEach({ (index, value) in
             switch value {
-            case let value as Int:
-                try encode(value)
             case let value as Bool:
+                try encode(value)
+            case let value as Int:
                 try encode(value)
             case let value as String:
                 try encode(value)

--- a/OmiseSwiftTests/DecoderTest.swift
+++ b/OmiseSwiftTests/DecoderTest.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+class DecodeTests: XCTestCase {
+    
+    func jsonData(withFileName name: String) throws -> Data {
+        let bundle = Bundle(for: FixtureClient.self)
+        let directoryURL = bundle.url(forResource: "Fixtures/objects", withExtension: nil)!
+        let filePath = (name as NSString).appendingPathExtension("json")! as String
+        let fixtureFileURL = directoryURL.appendingPathComponent(filePath)
+        return try Data(contentsOf: fixtureFileURL)
+    }
+    
+    func testAnyJSONTypeDecoding() {
+        do {
+            let jsonData = try self.jsonData(withFileName: "metadata")
+            let decodedData =  try JSONDecoder().decode(MetadataDummy.self, from: jsonData)
+            let metadata = decodedData.metadata
+            XCTAssertEqual(metadata["a_string"] as? String, "some_string")
+            XCTAssertEqual(metadata["an_integer"] as? Int, 1)
+            XCTAssertEqual(metadata["a_bool"] as? Bool, true)
+            XCTAssertEqual(metadata["a_double"] as? Double, 12.34)
+            guard let object: [String: Any] = metadata["an_object"] as? [String: Any] else {
+                XCTFail("could not decode object")
+                return
+            }
+            XCTAssertEqual(object["a_key"] as? String, "a_value")
+            guard let nestedObject: [String: Any] = object["a_nested_object"] as? [String: Any] else {
+                XCTFail("Could not decode nested object")
+                return
+            }
+            XCTAssertEqual(nestedObject["a_nested_key"] as? String, "a_nested_value")
+            guard let array: [Any] = metadata["an_array"] as? [Any] else {
+                XCTFail("Could not decode array")
+                return
+            }
+            XCTAssertTrue(array.count == 2)
+            XCTAssertEqual(array[0] as? String, "value_1")
+            XCTAssertEqual(array[1] as? String, "value_2")
+        } catch let thrownError {
+            XCTFail(thrownError.localizedDescription)
+        }
+    }
+}
+

--- a/OmiseSwiftTests/Fixtures/objects/metadata.json
+++ b/OmiseSwiftTests/Fixtures/objects/metadata.json
@@ -1,0 +1,17 @@
+{
+  "metadata":{
+    "a_string": "some_string",
+    "an_integer": 1,
+    "a_bool": true,
+    "a_double": 12.34,
+    "an_object": {
+      "a_key": "a_value",
+      "a_nested_object": {
+        "a_nested_key": "a_nested_value"
+      }
+    },
+    "an_array": [
+                 "value_1", "value_2"
+                 ]
+  }
+}

--- a/OmiseSwiftTests/URLEncoderTest.swift
+++ b/OmiseSwiftTests/URLEncoderTest.swift
@@ -310,3 +310,20 @@ class URLEncoderTest: OmiseTestCase {
         XCTAssertEqual("66473", result[7].value)
     }
 }
+
+
+struct MetadataDummy: Decodable {
+    
+    let metadata: [String: Any]
+    
+    private enum CodingKeys: String, CodingKey {
+        case metadata
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        metadata = try container.decode([String: Any].self, forKey: .metadata)
+    }
+}
+
+


### PR DESCRIPTION
The JSONDecoder use the NSJSONSerialization class under the hood which decoded its number to NSNumber. However NSNumber has an ability to decode the Boolean number as an Int which can cause the Decoder to decode it as a wrong type.

This PR change the order when trying to decode the JSONDictionary type to avoid this leaky abstraction bug