### PR TITLE
Add PromptPay and PayNow to payment sources

### DIFF
--- a/OmiseSwift/API Models/Source.swift
+++ b/OmiseSwift/API Models/Source.swift
@@ -343,6 +343,7 @@ public struct PaymentSourceParams: APIJSONQuery {
         case barcode(Barcode)
         case installment(Installment.CreateParameter)
         case promtPay
+        case payNow
         
         case unknown(String)
         
@@ -375,6 +376,8 @@ public struct PaymentSourceParams: APIJSONQuery {
                 return .installment(installment.brand)
             case .promtPay:
                 return .promptPay
+            case .payNow:
+                return .payNow
             case .unknown(name: let sourceName):
                 return Omise.SourceType.unknown(sourceName)
             }

--- a/OmiseSwift/API Models/Source.swift
+++ b/OmiseSwift/API Models/Source.swift
@@ -342,7 +342,7 @@ public struct PaymentSourceParams: APIJSONQuery {
         case billPayment(SourceType.BillPayment)
         case barcode(Barcode)
         case installment(Installment.CreateParameter)
-        case promtPay
+        case promptPay
         case payNow
         
         case unknown(String)
@@ -374,7 +374,7 @@ public struct PaymentSourceParams: APIJSONQuery {
                 
             case .installment(let installment):
                 return .installment(installment.brand)
-            case .promtPay:
+            case .promptPay:
                 return .promptPay
             case .payNow:
                 return .payNow

--- a/OmiseSwift/API Models/Source.swift
+++ b/OmiseSwift/API Models/Source.swift
@@ -342,6 +342,7 @@ public struct PaymentSourceParams: APIJSONQuery {
         case billPayment(SourceType.BillPayment)
         case barcode(Barcode)
         case installment(Installment.CreateParameter)
+        case promtPay
         
         case unknown(String)
         
@@ -372,6 +373,8 @@ public struct PaymentSourceParams: APIJSONQuery {
                 
             case .installment(let installment):
                 return .installment(installment.brand)
+            case .promtPay:
+                return .promptPay
             case .unknown(name: let sourceName):
                 return Omise.SourceType.unknown(sourceName)
             }

--- a/OmiseSwift/API Models/Source/PaymentSource.swift
+++ b/OmiseSwift/API Models/Source/PaymentSource.swift
@@ -29,6 +29,8 @@ public struct PaymentSource: SourceData, OmiseResourceObject {
         case billPayment(SourceType.BillPayment)
         case barcode(Barcode)
         case installment(Installment)
+        case promptPay
+        case payNow
         
         case unknown(String)
         
@@ -59,6 +61,10 @@ public struct PaymentSource: SourceData, OmiseResourceObject {
                 
             case .installment(let installment):
                 return .installment(installment.brand)
+            case .promptPay:
+                return .promptPay
+            case .payNow:
+                return .payNow
             case .unknown(name: let sourceName):
                 return Omise.SourceType.unknown(sourceName)
             }
@@ -102,6 +108,10 @@ public struct PaymentSource: SourceData, OmiseResourceObject {
                 }
             } else if typeValue.hasPrefix(installmentPrefix) {
                 self = .installment(try Installment(from: decoder))
+            } else if typeValue == promptPayValue {
+                self = .promptPay
+            } else if typeValue == payNowValue {
+                self = .payNow
             } else {
                 self = .unknown(typeValue)
             }

--- a/OmiseSwiftTests/ChargesOperationFixtureTests.swift
+++ b/OmiseSwiftTests/ChargesOperationFixtureTests.swift
@@ -1122,7 +1122,7 @@ class ChargesOperationFixtureTests: FixtureTestCase {
     }
     
     func testEncodingCreatePayNowChargeParams() throws {
-        let params = ChargeParams(value: Value(amount: 10_000_00, currency: .thb),
+        let params = ChargeParams(value: Value(amount: 10_000_00, currency: .sgd),
                                   sourceType: .payNow,
                                   chargeDescription: "Test",
                                   metadata: ["customer_id": "123"])
@@ -1136,7 +1136,7 @@ class ChargesOperationFixtureTests: FixtureTestCase {
         XCTAssertEqual(items[0].name, "amount")
         XCTAssertEqual(items[0].value, "1000000")
         XCTAssertEqual(items[1].name, "currency")
-        XCTAssertEqual(items[1].value, "THB")
+        XCTAssertEqual(items[1].value, "SGD")
         XCTAssertEqual(items[2].name, "source[type]")
         XCTAssertEqual(items[2].value, "paynow")
         XCTAssertEqual(items[3].name, "description")

--- a/OmiseSwiftTests/ChargesOperationFixtureTests.swift
+++ b/OmiseSwiftTests/ChargesOperationFixtureTests.swift
@@ -1097,9 +1097,9 @@ class ChargesOperationFixtureTests: FixtureTestCase {
         XCTAssertEqual(items[5].value, "1")
     }
     
-    func testEncodingCreatePromtPayChargeParams() throws {
+    func testEncodingCreatePromptPayChargeParams() throws {
         let params = ChargeParams(value: Value(amount: 10_000_00, currency: .thb),
-                                  sourceType: .promtPay,
+                                  sourceType: .promptPay,
                                   chargeDescription: "Test",
                                   metadata: ["customer_id": "123"])
         

--- a/OmiseSwiftTests/ChargesOperationFixtureTests.swift
+++ b/OmiseSwiftTests/ChargesOperationFixtureTests.swift
@@ -1114,6 +1114,23 @@ class ChargesOperationFixtureTests: FixtureTestCase {
         XCTAssertEqual(items[2].value, "promptpay")
     }
     
+    func testEncodingCreatePayNowChargeParams() throws {
+        let params = ChargeParams(value: Value(amount: 10_000_00, currency: .thb), sourceType: .payNow)
+        
+        let encoder = URLQueryItemEncoder()
+        encoder.arrayIndexEncodingStrategy = .emptySquareBrackets
+        
+        let items = try encoder.encode(params)
+        
+        XCTAssertEqual(items.count, 3)
+        XCTAssertEqual(items[0].name, "amount")
+        XCTAssertEqual(items[0].value, "1000000")
+        XCTAssertEqual(items[1].name, "currency")
+        XCTAssertEqual(items[1].value, "THB")
+        XCTAssertEqual(items[2].name, "source[type]")
+        XCTAssertEqual(items[2].value, "paynow")
+    }
+    
     func testEncodingCreateSourceChargeParams() throws {
         let source = PaymentSource(id: "src_test_12345", object: "source",
                                    isLiveMode: false, location: "/sources/src_test_12345",

--- a/OmiseSwiftTests/ChargesOperationFixtureTests.swift
+++ b/OmiseSwiftTests/ChargesOperationFixtureTests.swift
@@ -1098,37 +1098,51 @@ class ChargesOperationFixtureTests: FixtureTestCase {
     }
     
     func testEncodingCreatePromtPayChargeParams() throws {
-        let params = ChargeParams(value: Value(amount: 10_000_00, currency: .thb), sourceType: .promtPay)
+        let params = ChargeParams(value: Value(amount: 10_000_00, currency: .thb),
+                                  sourceType: .promtPay,
+                                  chargeDescription: "Test",
+                                  metadata: ["customer_id": "123"])
         
         let encoder = URLQueryItemEncoder()
         encoder.arrayIndexEncodingStrategy = .emptySquareBrackets
         
         let items = try encoder.encode(params)
         
-        XCTAssertEqual(items.count, 3)
+        XCTAssertEqual(items.count, 5)
         XCTAssertEqual(items[0].name, "amount")
         XCTAssertEqual(items[0].value, "1000000")
         XCTAssertEqual(items[1].name, "currency")
         XCTAssertEqual(items[1].value, "THB")
         XCTAssertEqual(items[2].name, "source[type]")
         XCTAssertEqual(items[2].value, "promptpay")
+        XCTAssertEqual(items[3].name, "description")
+        XCTAssertEqual(items[3].value, "Test")
+        XCTAssertEqual(items[4].name, "metadata[customer_id]")
+        XCTAssertEqual(items[4].value, "123")
     }
     
     func testEncodingCreatePayNowChargeParams() throws {
-        let params = ChargeParams(value: Value(amount: 10_000_00, currency: .thb), sourceType: .payNow)
+        let params = ChargeParams(value: Value(amount: 10_000_00, currency: .thb),
+                                  sourceType: .payNow,
+                                  chargeDescription: "Test",
+                                  metadata: ["customer_id": "123"])
         
         let encoder = URLQueryItemEncoder()
         encoder.arrayIndexEncodingStrategy = .emptySquareBrackets
         
         let items = try encoder.encode(params)
         
-        XCTAssertEqual(items.count, 3)
+        XCTAssertEqual(items.count, 5)
         XCTAssertEqual(items[0].name, "amount")
         XCTAssertEqual(items[0].value, "1000000")
         XCTAssertEqual(items[1].name, "currency")
         XCTAssertEqual(items[1].value, "THB")
         XCTAssertEqual(items[2].name, "source[type]")
         XCTAssertEqual(items[2].value, "paynow")
+        XCTAssertEqual(items[3].name, "description")
+        XCTAssertEqual(items[3].value, "Test")
+        XCTAssertEqual(items[4].name, "metadata[customer_id]")
+        XCTAssertEqual(items[4].value, "123")
     }
     
     func testEncodingCreateSourceChargeParams() throws {

--- a/OmiseSwiftTests/ChargesOperationFixtureTests.swift
+++ b/OmiseSwiftTests/ChargesOperationFixtureTests.swift
@@ -1097,6 +1097,23 @@ class ChargesOperationFixtureTests: FixtureTestCase {
         XCTAssertEqual(items[5].value, "1")
     }
     
+    func testEncodingCreatePromtPayChargeParams() throws {
+        let params = ChargeParams(value: Value(amount: 10_000_00, currency: .thb), sourceType: .promtPay)
+        
+        let encoder = URLQueryItemEncoder()
+        encoder.arrayIndexEncodingStrategy = .emptySquareBrackets
+        
+        let items = try encoder.encode(params)
+        
+        XCTAssertEqual(items.count, 3)
+        XCTAssertEqual(items[0].name, "amount")
+        XCTAssertEqual(items[0].value, "1000000")
+        XCTAssertEqual(items[1].name, "currency")
+        XCTAssertEqual(items[1].value, "THB")
+        XCTAssertEqual(items[2].name, "source[type]")
+        XCTAssertEqual(items[2].value, "promptpay")
+    }
+    
     func testEncodingCreateSourceChargeParams() throws {
         let source = PaymentSource(id: "src_test_12345", object: "source",
                                    isLiveMode: false, location: "/sources/src_test_12345",


### PR DESCRIPTION
Added PromptPay and PayNow to payment sources so they can be used to create a charge.