### PR TITLE
Fix Capability

### DIFF
--- a/OmiseSwift/API Models/Capability.swift
+++ b/OmiseSwift/API Models/Capability.swift
@@ -189,8 +189,6 @@ extension Capability.Method {
         let sourceTypeKey = try container.decode(Capability.Method.Key.self, forKey: .name)
         supportedCurrencies = try container.decode(Set<Currency>.self, forKey: .supportedCurrencies)
         
-        let methodConfigurations = try decoder.container(keyedBy: Capability.Method.CodingKeys.self)
-        
         switch sourceTypeKey {
         case .card:
             let paymentConfigurations = try decoder.container(keyedBy: Capability.Method.ConfigurationCodingKeys.self)
@@ -215,14 +213,14 @@ extension Capability.Method {
             self.payment = .payWithPoints
         case .source(SourceType.payWithPointsCiti):
             self.payment = .payWithPointsCiti
-        case .source(SourceType.unknown(let type)):
-            let configurations = try decoder.container(
-                keyedBy: SkippingKeyCodingKeys<Capability.Method.CodingKeys>.self).decode()
-            self.payment = .unknownSource(type, configurations: configurations)
         case .source(SourceType.billPayment(let billPayment)):
             self.payment = .billPayment(billPayment)
         case .source(SourceType.barcode(let barcode)):
             self.payment = .barcode(barcode)
+        case .source(SourceType.unknown(let type)):
+            let configurations = try decoder.container(
+                keyedBy: SkippingKeyCodingKeys<Capability.Method.CodingKeys>.self).decode()
+            self.payment = .unknownSource(type, configurations: configurations)
         }
     }
     
@@ -278,10 +276,10 @@ extension Capability.Method {
             try methodConfigurations.encode(Key.source(.payWithPoints), forKey: .name)
             
         case .payWithPointsCiti:
-        var methodConfigurations = encoder.container(keyedBy: Capability.Method.CodingKeys.self)
+            var methodConfigurations = encoder.container(keyedBy: Capability.Method.CodingKeys.self)
         
-        try methodConfigurations.encode(Array(supportedCurrencies), forKey: .supportedCurrencies)
-        try methodConfigurations.encode(Key.source(.payWithPointsCiti), forKey: .name)
+            try methodConfigurations.encode(Array(supportedCurrencies), forKey: .supportedCurrencies)
+            try methodConfigurations.encode(Key.source(.payWithPointsCiti), forKey: .name)
             
         case .billPayment(let billPayment):
             var methodConfigurations = encoder.container(keyedBy: Capability.Method.CodingKeys.self)

--- a/OmiseSwift/API Models/Capability.swift
+++ b/OmiseSwift/API Models/Capability.swift
@@ -139,9 +139,19 @@ extension Capability.Method.Payment {
         switch (lhs, rhs) {
         case (.card, .card), (.alipay, .alipay):
             return true
-        case (.installment(let lhsValue), .installment(let rhsValue)):
-            return lhsValue == rhsValue
+        case (.promptPay, .promptPay), (.payNow, .payNow):
+            return true
+        case (.truemoney, .truemoney):
+            return true
+        case (.payWithPoints, .payWithPoints), (.payWithPointsCiti, .payWithPointsCiti):
+            return true
+        case (.installment(let lhsBrand, let lhsNumberOfTerms), .installment(let rhsBrand, let rhsNumberOfTerms)):
+            return lhsBrand == rhsBrand && lhsNumberOfTerms == rhsNumberOfTerms
         case (.internetBanking(let lhsValue), .internetBanking(let rhsValue)):
+            return lhsValue == rhsValue
+        case (.billPayment(let lhsValue), .billPayment(let rhsValue)):
+            return lhsValue == rhsValue
+        case (.barcode(let lhsValue), .barcode(let rhsValue)):
             return lhsValue == rhsValue
         default:
             return false

--- a/OmiseSwift/API Models/Capability.swift
+++ b/OmiseSwift/API Models/Capability.swift
@@ -92,6 +92,7 @@ extension Capability {
             case installment(SourceType.InstallmentBrand, availableNumberOfTerms: IndexSet)
             case internetBanking(InternetBanking)
             case billPayment(SourceType.BillPayment)
+            case barcode(SourceType.Barcode)
             case alipay
             case promptPay
             case payNow
@@ -220,10 +221,8 @@ extension Capability.Method {
             self.payment = .unknownSource(type, configurations: configurations)
         case .source(SourceType.billPayment(let billPayment)):
             self.payment = .billPayment(billPayment)
-        case .source(SourceType.barcode):
-            throw DecodingError.dataCorruptedError(
-                forKey: Capability.Method.CodingKeys.name, in: methodConfigurations,
-                debugDescription: "Invalid payment method type value")
+        case .source(SourceType.barcode(let barcode)):
+            self.payment = .barcode(barcode)
         }
     }
     
@@ -289,6 +288,12 @@ extension Capability.Method {
             
             try methodConfigurations.encode(Array(supportedCurrencies), forKey: .supportedCurrencies)
             try methodConfigurations.encode(Key.source(.billPayment(billPayment)), forKey: .name)
+            
+        case .barcode(let barcode):
+            var methodConfigurations = encoder.container(keyedBy: Capability.Method.CodingKeys.self)
+            
+            try methodConfigurations.encode(Array(supportedCurrencies), forKey: .supportedCurrencies)
+            try methodConfigurations.encode(Key.source(.barcode(barcode)), forKey: .name)
             
         case .unknownSource(let source, configurations: let configurations):
             var configurationContainers = encoder.container(
@@ -373,6 +378,8 @@ extension Capability.Method {
                 self = .source(.payWithPointsCiti)
             case .billPayment(let billPayment):
                 self = .source(.billPayment(billPayment))
+            case .barcode(let barcode):
+                self = .source(.barcode(barcode))
             case .unknownSource(let sourceType, configurations: _):
                 self = .source(.unknown(sourceType))
             }

--- a/OmiseSwiftTests/CapabilityOperationFixtureTests.swift
+++ b/OmiseSwiftTests/CapabilityOperationFixtureTests.swift
@@ -11,11 +11,11 @@ class CapabilityOperationFixtureTests: FixtureTestCase {
             
             switch result {
             case let .success(capability):
-                XCTAssertEqual(capability.supportedMethods.count, 6)
+                XCTAssertEqual(capability.supportedMethods.count, 16)
                 
                 if let creditCardMethod = capability.creditCardMethod {
                     XCTAssertEqual(creditCardMethod.payment, .card([]))
-                    XCTAssertEqual(creditCardMethod.supportedCurrencies, [.thb, .jpy, .usd, .eur, .gbp, .sgd])
+                    XCTAssertEqual(creditCardMethod.supportedCurrencies, [.thb, .jpy, .usd, .eur, .gbp, .sgd, .aud, .chf, .cny, .dkk, .hkd])
                 } else {
                     XCTFail("Capability doesn't have the Credit Card backend")
                 }

--- a/OmiseSwiftTests/Fixtures/api.omise.co/capability-get.json
+++ b/OmiseSwiftTests/Fixtures/api.omise.co/capability-get.json
@@ -45,13 +45,63 @@
         "USD",
         "EUR",
         "GBP",
-        "SGD"
+        "SGD",
+        "AUD",
+        "CHF",
+        "CNY",
+        "DKK",
+        "HKD"
       ],
       "card_brands": [
         "JCB",
         "Visa",
         "MasterCard"
       ],
+      "installment_terms": null
+    },
+    {
+      "object": "payment_method",
+      "name": "internet_banking_bay",
+      "currencies": [
+        "THB"
+      ],
+      "card_brands": null,
+      "installment_terms": null
+    },
+    {
+      "object": "payment_method",
+      "name": "internet_banking_ktb",
+      "currencies": [
+        "THB"
+      ],
+      "card_brands": null,
+      "installment_terms": null
+    },
+    {
+      "object": "payment_method",
+      "name": "internet_banking_scb",
+      "currencies": [
+        "THB"
+      ],
+      "card_brands": null,
+      "installment_terms": null
+    },
+    {
+      "object": "payment_method",
+      "name": "internet_banking_bbl",
+      "currencies": [
+        "THB"
+      ],
+      "card_brands": null,
+      "installment_terms": null
+    },
+    {
+      "object": "payment_method",
+      "name": "alipay",
+      "currencies": [
+        "THB"
+      ],
+      "card_brands": null,
       "installment_terms": null
     },
     {
@@ -65,6 +115,53 @@
         3,
         4,
         6,
+        9,
+        10
+      ]
+    },
+    {
+      "object": "payment_method",
+      "name": "installment_kbank",
+      "currencies": [
+        "THB"
+      ],
+      "card_brands": null,
+      "installment_terms": [
+        3,
+        4,
+        6,
+        10
+      ]
+    },
+    {
+      "object": "payment_method",
+      "name": "installment_ktc",
+      "currencies": [
+        "THB"
+      ],
+      "card_brands": null,
+      "installment_terms": [
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ]
+    },
+    {
+      "object": "payment_method",
+      "name": "installment_bbl",
+      "currencies": [
+        "THB"
+      ],
+      "card_brands": null,
+      "installment_terms": [
+        4,
+        6,
+        8,
         9,
         10
       ]
@@ -90,51 +187,50 @@
     },
     {
       "object": "payment_method",
-      "name": "installment_kbank",
+      "name": "bill_payment_tesco_lotus",
       "currencies": [
         "THB"
       ],
       "card_brands": null,
-      "installment_terms": [
-        3,
-        4,
-        6,
-        10
-      ]
+      "installment_terms": null
     },
     {
       "object": "payment_method",
-      "name": "installment_bbl",
+      "name": "barcode_alipay",
       "currencies": [
         "THB"
       ],
       "card_brands": null,
-      "installment_terms": [
-        4,
-        6,
-        8,
-        9,
-        10
-      ]
+      "installment_terms": null
     },
     {
       "object": "payment_method",
-      "name": "installment_ktc",
+      "name": "promptpay",
       "currencies": [
         "THB"
       ],
       "card_brands": null,
-      "installment_terms": [
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ]
+      "installment_terms": null
+    },
+    {
+      "object": "payment_method",
+      "name": "points_citi",
+      "currencies": [
+        "THB"
+      ],
+      "card_brands": null,
+      "installment_terms": null
+    },
+    {
+      "object": "payment_method",
+      "name": "truemoney",
+      "currencies": [
+        "THB"
+      ],
+      "card_brands": null,
+      "installment_terms": null
     }
   ],
-  "zero_interest_installments": true
+  "country": "TH",
+  "zero_interest_installments": false
 }


### PR DESCRIPTION
**1. Objective**

The source types `Bill Payment` and `Barcode` are not probably setup as valid payment methods in the Capability object. As a result it's not possible to receive any Capabilities when one of them is enabled in the account settings.

**2. Description of change**

Added `Bill Payment` and `Barcode` as valid payment methods to the Capability object.

**3. Quality assurance**

N/A

**4. Operations impact**

N/A

**5. Business impact**

N/A

**6. Priority of change**

Normal