### PR TITLE
Fix decoding of unknown sources

### DIFF
--- a/OmiseSwift/API Models/Source/EnrolledSource.swift
+++ b/OmiseSwift/API Models/Source/EnrolledSource.swift
@@ -232,8 +232,8 @@ extension EnrolledSource.EnrolledPaymentInformation {
                 let billInformation = try container.decode(BillPayment.BillInformation.self, forKey: .references)
                 self = .billPayment(.tescoLotus(billInformation))
             case let billPaymentType:
-                let references = try container.decode(Dictionary<String, Any>.self, forKey: .references)
-                self = .billPayment(.unknown(name: billPaymentType, references: references))
+                let references = try container.decodeIfPresent(Dictionary<String, Any>.self, forKey: .references)
+                self = .billPayment(.unknown(name: billPaymentType, references: references ?? [:]))
             }
         } else if typeValue.hasPrefix(barcodePrefix),
             let barcodeValue = typeValue
@@ -243,8 +243,8 @@ extension EnrolledSource.EnrolledPaymentInformation {
                 let alipayBarcode = try container.decode(Barcode.AlipayBarcode.self, forKey: .references)
                 self = .barcode(.alipay(alipayBarcode))
             case let barcodeType:
-                let references = try container.decode(Dictionary<String, Any>.self, forKey: .references)
-                self = .barcode(.unknown(name: barcodeType, references: references))
+                let references = try container.decodeIfPresent(Dictionary<String, Any>.self, forKey: .references)
+                self = .barcode(.unknown(name: barcodeType, references: references ?? [:]))
             }
         } else if typeValue.hasPrefix(installmentPrefix),
             let installmentValue = typeValue


### PR DESCRIPTION
**1. Objective**

We expect that every source of type "Barcode" or "Bill Payment" has reference information. If `references` is `null` the whole decoding will fail. This affects retrieving charges. As soon as there is a new source of one of this types without `references` (e.g. WeChat Pay) decoding of all charges will fail. 

**2. Description of change**

Changed decoding of `references` for unknown sources of type "Barcode" or "Bill Payment" to optional to allow `null` values.

**3. Quality assurance**

N/A

**4. Operations impact**

N/A

**5. Business impact**

N/A

**6. Priority of change**

Normal