### PR TITLE
Fix authorized url variable name

### DIFF
--- a/OmiseSwift/API Models/Charge.swift
+++ b/OmiseSwift/API Models/Charge.swift
@@ -100,7 +100,7 @@ public struct Charge: OmiseResourceObject, Equatable {
     public var dispute: Dispute?
     
     public let returnURL: URL?
-    public let authorizedURL: URL?
+    public let authorizeURL: URL?
     
     public let metadata: JSONDictionary
 }
@@ -190,7 +190,7 @@ extension Charge {
         case ipAddress = "ip"
         case dispute
         case returnURL = "return_uri"
-        case authorizedURL = "authorized_uri"
+        case authorizeURL = "authorize_uri"
         case metadata
     }
     
@@ -234,7 +234,7 @@ extension Charge {
         link = try container.decodeIfPresent(DetailProperty<Link>.self, forKey: .link)
         dispute = try container.decodeIfPresent(Dispute.self, forKey: .dispute)
         returnURL = try container.decodeIfPresent(URL.self, forKey: .returnURL)
-        authorizedURL = try container.decodeIfPresent(URL.self, forKey: .authorizedURL)
+        authorizeURL = try container.decodeIfPresent(URL.self, forKey: .authorizeURL)
         metadata = try container.decode([String: Any].self, forKey: .metadata)
         
         let statusValue = try container.decode(String.self, forKey: .status)
@@ -318,7 +318,7 @@ extension Charge {
         try container.encodeIfPresent(schedule, forKey: .schedule)
         try container.encodeIfPresent(link, forKey: .link)
         try container.encodeIfPresent(returnURL, forKey: .returnURL)
-        try container.encodeIfPresent(authorizedURL, forKey: .authorizedURL)
+        try container.encodeIfPresent(authorizeURL, forKey: .authorizeURL)
         try container.encode(metadata, forKey: .metadata)
         
         switch status {

--- a/OmiseSwiftTests/ChargesOperationFixtureTests.swift
+++ b/OmiseSwiftTests/ChargesOperationFixtureTests.swift
@@ -68,7 +68,7 @@ class ChargesOperationFixtureTests: FixtureTestCase {
         XCTAssertEqual(defaultCharge.refunds.total, decodedCharge.refunds.total)
 
         XCTAssertEqual(defaultCharge.returnURL, decodedCharge.returnURL)
-        XCTAssertEqual(defaultCharge.authorizedURL, decodedCharge.authorizedURL)
+        XCTAssertEqual(defaultCharge.authorizeURL, decodedCharge.authorizeURL)
         
         XCTAssertEqual(defaultCharge.card?.object, decodedCharge.card?.object)
         XCTAssertEqual(defaultCharge.card?.id, decodedCharge.card?.id)
@@ -161,7 +161,7 @@ class ChargesOperationFixtureTests: FixtureTestCase {
         XCTAssertEqual(defaultCharge.refunds.total, decodedCharge.refunds.total)
         
         XCTAssertEqual(defaultCharge.returnURL, decodedCharge.returnURL)
-        XCTAssertEqual(defaultCharge.authorizedURL, decodedCharge.authorizedURL)
+        XCTAssertEqual(defaultCharge.authorizeURL, decodedCharge.authorizeURL)
         
         XCTAssertEqual(defaultCharge.card?.object, decodedCharge.card?.object)
         XCTAssertEqual(defaultCharge.card?.id, decodedCharge.card?.id)
@@ -514,7 +514,7 @@ class ChargesOperationFixtureTests: FixtureTestCase {
         XCTAssertEqual(defaultCharge.refunds.total, decodedCharge.refunds.total)
         
         XCTAssertEqual(defaultCharge.returnURL, decodedCharge.returnURL)
-        XCTAssertEqual(defaultCharge.authorizedURL, decodedCharge.authorizedURL)
+        XCTAssertEqual(defaultCharge.authorizeURL, decodedCharge.authorizeURL)
         XCTAssertEqual(defaultCharge.createdDate, decodedCharge.createdDate)
         
         XCTAssertEqual(defaultCharge.source?.object, decodedCharge.source?.object)
@@ -578,7 +578,7 @@ class ChargesOperationFixtureTests: FixtureTestCase {
         XCTAssertEqual(defaultCharge.refunds.total, decodedCharge.refunds.total)
         
         XCTAssertEqual(defaultCharge.returnURL, decodedCharge.returnURL)
-        XCTAssertEqual(defaultCharge.authorizedURL, decodedCharge.authorizedURL)
+        XCTAssertEqual(defaultCharge.authorizeURL, decodedCharge.authorizeURL)
         XCTAssertEqual(defaultCharge.createdDate, decodedCharge.createdDate)
         
         XCTAssertEqual(defaultCharge.source?.object, decodedCharge.source?.object)
@@ -968,7 +968,7 @@ class ChargesOperationFixtureTests: FixtureTestCase {
         XCTAssertEqual(defaultCharge.refunds.total, decodedCharge.refunds.total)
         
         XCTAssertEqual(defaultCharge.returnURL, decodedCharge.returnURL)
-        XCTAssertEqual(defaultCharge.authorizedURL, decodedCharge.authorizedURL)
+        XCTAssertEqual(defaultCharge.authorizeURL, decodedCharge.authorizeURL)
         XCTAssertEqual(defaultCharge.createdDate, decodedCharge.createdDate)
         
         XCTAssertEqual(defaultCharge.source?.object, decodedCharge.source?.object)
@@ -1279,7 +1279,7 @@ class ChargesOperationFixtureTests: FixtureTestCase {
         XCTAssertEqual(defaultCharge.refunds.total, decodedCharge.refunds.total)
         
         XCTAssertEqual(defaultCharge.returnURL, decodedCharge.returnURL)
-        XCTAssertEqual(defaultCharge.authorizedURL, decodedCharge.authorizedURL)
+        XCTAssertEqual(defaultCharge.authorizeURL, decodedCharge.authorizeURL)
         
         XCTAssertEqual(defaultCharge.card?.object, decodedCharge.card?.object)
         XCTAssertEqual(defaultCharge.card?.id, decodedCharge.card?.id)
@@ -1357,7 +1357,7 @@ class ChargesOperationFixtureTests: FixtureTestCase {
         XCTAssertEqual(defaultCharge.refunds.total, decodedCharge.refunds.total)
         
         XCTAssertEqual(defaultCharge.returnURL, decodedCharge.returnURL)
-        XCTAssertEqual(defaultCharge.authorizedURL, decodedCharge.authorizedURL)
+        XCTAssertEqual(defaultCharge.authorizeURL, decodedCharge.authorizeURL)
         XCTAssertEqual(defaultCharge.createdDate, decodedCharge.createdDate)
         
         XCTAssertEqual(defaultCharge.source?.object, decodedCharge.source?.object)
@@ -1434,7 +1434,7 @@ class ChargesOperationFixtureTests: FixtureTestCase {
         XCTAssertEqual(defaultCharge.refunds.total, decodedCharge.refunds.total)
         
         XCTAssertEqual(defaultCharge.returnURL, decodedCharge.returnURL)
-        XCTAssertEqual(defaultCharge.authorizedURL, decodedCharge.authorizedURL)
+        XCTAssertEqual(defaultCharge.authorizeURL, decodedCharge.authorizeURL)
         XCTAssertEqual(defaultCharge.createdDate, decodedCharge.createdDate)
         
         XCTAssertEqual(defaultCharge.source?.object, decodedCharge.source?.object)

--- a/OmiseSwiftTests/LinkOperationFixtureTest.swift
+++ b/OmiseSwiftTests/LinkOperationFixtureTest.swift
@@ -75,7 +75,7 @@ class LinkOperationFixtureTest: FixtureTestCase {
         XCTAssertEqual(defaultCharge.source?.id, decodedCharge.source?.id)
         XCTAssertEqual(defaultCharge.location, decodedCharge.location)
         XCTAssertEqual(defaultCharge.returnURL, decodedCharge.returnURL)
-        XCTAssertEqual(defaultCharge.authorizedURL, decodedCharge.authorizedURL)
+        XCTAssertEqual(defaultCharge.authorizeURL, decodedCharge.authorizeURL)
         
         XCTAssertEqual(defaultCharge.card, decodedCharge.card)
         XCTAssertEqual(defaultCharge.card?.object, decodedCharge.card?.object)


### PR DESCRIPTION
Fix issue where authorized_url should actually be authorize_url, this lead to the authorize_url not being mapped from charge object.