### PR TITLE
Fix decoding issues of charges

### DIFF
--- a/OmiseSwift/API Models/Charge.swift
+++ b/OmiseSwift/API Models/Charge.swift
@@ -263,7 +263,7 @@ extension Charge {
         
         self.status = status
         
-        source = try container.decodeIfPresent(EnrolledSource.self, forKey: .source)
+        source = try? container.decodeIfPresent(EnrolledSource.self, forKey: .source)
         card = try container.decodeIfPresent(Card.self, forKey: .card)
         
         switch (card, source) {

--- a/OmiseSwift/API Models/Source/EnrolledSource.swift
+++ b/OmiseSwift/API Models/Source/EnrolledSource.swift
@@ -8,8 +8,8 @@ public struct EnrolledSource: SourceData {
         case internetBanking(InternetBanking)
         case mobileBanking(MobileBanking)
         case alipay
-        case promptPay(ScannableCode)
-        case payNow(ScannableCode)
+        case promptPay(ScannableCode?)
+        case payNow(ScannableCode?)
         case billPayment(BillPayment)
         case barcode(Barcode)
         case installment(SourceType.InstallmentBrand)
@@ -20,7 +20,7 @@ public struct EnrolledSource: SourceData {
         
         public enum BillPayment: Equatable {
             
-            case tescoLotus(BillInformation)
+            case tescoLotus(BillInformation?)
             case unknown(name: String, references: [String: Any])
             
             public struct BillInformation: Codable, Equatable {
@@ -51,7 +51,7 @@ public struct EnrolledSource: SourceData {
         }
         
         public enum Barcode: Equatable {
-            case alipay(AlipayBarcode)
+            case alipay(AlipayBarcode?)
             case weChatPay
             case unknown(name: String, references: [String: Any])
             

--- a/OmiseSwift/Models/ListProperty.swift
+++ b/OmiseSwift/Models/ListProperty.swift
@@ -14,6 +14,21 @@ public struct ListProperty<Item: OmiseObject>: OmiseObject {
     public var offset: Int
     
     public var data: [Item]
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        object = try container.decode(String.self, forKey: .object)
+        location = try container.decode(String.self, forKey: .location)
+        from = try container.decode(Date.self, forKey: .from)
+        to = try container.decode(Date.self, forKey: .to)
+        limit = try container.decode(Int.self, forKey: .limit)
+        total = try container.decode(Int.self, forKey: .total)
+        offset = try container.decode(Int.self, forKey: .offset)
+
+        let decodedData = try container.decode([DecodingResult<Item>].self, forKey: .data)
+        data = decodedData.compactMap { try? $0.result.get() }
+    }
 }
 
 extension ListProperty: RandomAccessCollection {
@@ -57,3 +72,10 @@ extension ListProperty: Equatable where Item: Equatable {
     }
 }
 
+private struct DecodingResult<T: Decodable>: Decodable {
+    let result: Result<T, Error>
+
+    init(from decoder: Decoder) throws {
+        result = Result { try T(from: decoder) }
+    }
+}

--- a/OmiseSwiftTests/ChargesOperationFixtureTests.swift
+++ b/OmiseSwiftTests/ChargesOperationFixtureTests.swift
@@ -605,10 +605,10 @@ class ChargesOperationFixtureTests: FixtureTestCase {
                 XCTAssertEqual(charge.source?.flow, .offline)
                 switch charge.source?.paymentInformation {
                 case EnrolledSource.EnrolledPaymentInformation.billPayment(.tescoLotus(let bill))?:
-                    XCTAssertEqual(bill.omiseTaxID, "0105556091152")
-                    XCTAssertEqual(bill.referenceNumber1, "068263727885787840")
-                    XCTAssertEqual(bill.referenceNumber2, "060028266962275319")
-                    XCTAssertEqual(bill.barcodeURL, URL(string:
+                    XCTAssertEqual(bill?.omiseTaxID, "0105556091152")
+                    XCTAssertEqual(bill?.referenceNumber1, "068263727885787840")
+                    XCTAssertEqual(bill?.referenceNumber2, "060028266962275319")
+                    XCTAssertEqual(bill?.barcodeURL, URL(string:
                         """
                         https://api.omise.co/charges/chrg_test_5fzc7srreh7yj3oh6k0/\
                         documents/docu_test_5fzc7stfx9z2u3ohh4a/downloads/B6958F0720700012
@@ -665,6 +665,8 @@ class ChargesOperationFixtureTests: FixtureTestCase {
         switch (defaultCharge.source?.paymentInformation, decodedCharge.source?.paymentInformation) {
         case (EnrolledSource.EnrolledPaymentInformation.billPayment(.tescoLotus(let bill))?,
               EnrolledSource.EnrolledPaymentInformation.billPayment(.tescoLotus(let decodedBill))?):
+            let bill = try XCTUnwrap(bill)
+            let decodedBill = try XCTUnwrap(decodedBill)
             XCTAssertEqual(bill.omiseTaxID, decodedBill.omiseTaxID)
             XCTAssertEqual(bill.referenceNumber1, decodedBill.referenceNumber1)
             XCTAssertEqual(bill.referenceNumber2, decodedBill.referenceNumber2)
@@ -716,7 +718,7 @@ class ChargesOperationFixtureTests: FixtureTestCase {
                 XCTAssertEqual(charge.source?.flow, .offline)
                 switch charge.source?.paymentInformation {
                 case .barcode(.alipay(let alipayBarcode))?:
-                    XCTAssertEqual(alipayBarcode.expiredDate, dateFormatter.date(from: "2019-05-23T06:00:30Z"))
+                    XCTAssertEqual(alipayBarcode?.expiredDate, dateFormatter.date(from: "2019-05-23T06:00:30Z"))
                 default:
                     XCTFail("Wrong source information on Testco Lotus Bill Payment charge")
                 }
@@ -774,12 +776,12 @@ class ChargesOperationFixtureTests: FixtureTestCase {
                 XCTAssertEqual(charge.source?.flow, .offline)
                 switch charge.source?.paymentInformation {
                 case .promptPay(let scannableCode)?:
-                    let image = scannableCode.image
-                    XCTAssertEqual(scannableCode.object, "barcode")
-                    XCTAssertEqual(image.id, "docu_test_5jcmh5zy9loubnch5th")
-                    XCTAssertEqual(image.filename, "qrcode.png")
-                    XCTAssertEqual(image.location, "/charges/chrg_test_5jcmh5y5z3g5hurbu8o/documents/docu_test_5jcmh5zy9loubnch5th")
-                    XCTAssertEqual(image.downloadURL?.absoluteString, "https://api.omise.co/charges/chrg_test_5jcmh5y5z3g5hurbu8o/documents/docu_test_5jcmh5zy9loubnch5th/downloads/25624FE66C9AA7F7")
+                    let image = scannableCode?.image
+                    XCTAssertEqual(scannableCode?.object, "barcode")
+                    XCTAssertEqual(image?.id, "docu_test_5jcmh5zy9loubnch5th")
+                    XCTAssertEqual(image?.filename, "qrcode.png")
+                    XCTAssertEqual(image?.location, "/charges/chrg_test_5jcmh5y5z3g5hurbu8o/documents/docu_test_5jcmh5zy9loubnch5th")
+                    XCTAssertEqual(image?.downloadURL?.absoluteString, "https://api.omise.co/charges/chrg_test_5jcmh5y5z3g5hurbu8o/documents/docu_test_5jcmh5zy9loubnch5th/downloads/25624FE66C9AA7F7")
                 default:
                     XCTFail("Wrong source information on PromptPay charge")
                 }
@@ -808,12 +810,12 @@ class ChargesOperationFixtureTests: FixtureTestCase {
                 XCTAssertEqual(charge.source?.flow, .offline)
                 switch charge.source?.paymentInformation {
                 case .payNow(let scannableCode)?:
-                    let image = scannableCode.image
-                    XCTAssertEqual(scannableCode.object, "barcode")
-                    XCTAssertEqual(image.id, "docu_test_5jdsrqn9ziozwpylicq")
-                    XCTAssertEqual(image.filename, "qrcode.png")
-                    XCTAssertEqual(image.location, "/charges/chrg_test_5jdsrqlycr0rrwfzgkq/documents/docu_test_5jdsrqn9ziozwpylicq")
-                    XCTAssertEqual(image.downloadURL?.absoluteString, "https://api.omise.co/charges/chrg_test_5jdsrqlycr0rrwfzgkq/documents/docu_test_5jdsrqn9ziozwpylicq/downloads/D372681E6E6BFBA7")
+                    let image = scannableCode?.image
+                    XCTAssertEqual(scannableCode?.object, "barcode")
+                    XCTAssertEqual(image?.id, "docu_test_5jdsrqn9ziozwpylicq")
+                    XCTAssertEqual(image?.filename, "qrcode.png")
+                    XCTAssertEqual(image?.location, "/charges/chrg_test_5jdsrqlycr0rrwfzgkq/documents/docu_test_5jdsrqn9ziozwpylicq")
+                    XCTAssertEqual(image?.downloadURL?.absoluteString, "https://api.omise.co/charges/chrg_test_5jdsrqlycr0rrwfzgkq/documents/docu_test_5jdsrqn9ziozwpylicq/downloads/D372681E6E6BFBA7")
                 default:
                     XCTFail("Wrong source information on PromptPay charge")
                 }
@@ -1098,13 +1100,12 @@ class ChargesOperationFixtureTests: FixtureTestCase {
             case let .success(charge):
                 XCTAssertEqual(charge.id, chargeTestingID)
                 XCTAssertEqual(charge.location, "/charges/chrg_5lbteqohxzy2945n6wx")
-                XCTAssertEqual(charge.livemode, true)
-                XCTAssertEqual(charge.source?.flow, "redirect")
-                XCTAssertEqual(charge.source?.installment_term, 3)
-                XCTAssertEqual(charge.source?.type, "installment_scb")
-                XCTAssertEqual(charge.source?.charge_status, "pending")
-                XCTAssertEqual(charge.authorize_uri, "https://api.omise.co/payments/pay2_test_5lbtxbcqdd6g352o9yn/authorize")
-                XCTAssertEqual(charge.return_uri, "https://omise.co")
+                XCTAssertEqual(charge.isLiveMode, true)
+                XCTAssertEqual(charge.source?.flow, .redirect)
+                XCTAssertEqual(charge.source?.sourceType, .installment(.scb))
+                XCTAssertEqual(charge.status, .pending)
+                XCTAssertEqual(charge.authorizeURL?.absoluteString, "https://api.omise.co/payments/pay2_5lbteqokzg718tsqm1l/authorize")
+                XCTAssertEqual(charge.returnURL?.absoluteString, "https://omise.co")
             case let .failure(error):
                 XCTFail("\(error)")
             }

--- a/OmiseSwiftTests/Fixtures/api.omise.co/charges-get.json
+++ b/OmiseSwiftTests/Fixtures/api.omise.co/charges-get.json
@@ -9,6 +9,10 @@
   "location": "/charges",
   "data": [
     {
+        "object": "charge",
+        "id": "chrg_test_incomplete_json",
+    },
+    {
       "object": "charge",
       "id": "chrg_test_5fzcsz7y07vu6ddib17",
       "livemode": false,


### PR DESCRIPTION
**1. Objective**

In some cases it's not possible to retrieve the charge list. If one charge cannot be decoded the entire request will be canceled and an error will be thrown. One reason for this is that we expect too many infos for some payment methods. This PR should fix this issue. In addition, the framework should become more fault tolerant. If one charge cannot be decoded, all other charges should still be returned.

**2. Description of change**
- Changed the associated payment infos for the following payment methods to optional:
  - PromptPay
  - PayNow
  - Alipay Barcode
  - TescoLotus Bill Payment
- Changed the decoding of source infos to optional
- Changed the behavior when decoding the charges list to skip faulty charges 

**3. Quality assurance**
- Failed charges with no payment infos should still be decoded
- In a list of charges only faulty charges should be skipped; all other charges should be decoded

**4. Operations impact**
N/A

**5. Business impact**
N/A

**6. The priority of change**
Normal