### PR TITLE
Fix decoding of email in recipient

### DIFF
--- a/OmiseSwift/API Models/Recipient.swift
+++ b/OmiseSwift/API Models/Recipient.swift
@@ -74,7 +74,7 @@ extension Recipient {
         isDefault = try container.decode(Bool.self, forKey: .isDefault)
         failureCode = try container.decodeIfPresent(FailureCode.self, forKey: .failureCode)
         name = try container.decode(String.self, forKey: .name)
-        email = try container.decode(String.self, forKey: .email)
+        email = try container.decode(String?.self, forKey: .email)
         recipientDescription = try container.decodeIfPresent(String.self, forKey: .recipientDescription)
         type = try container.decode(RecipientType.self, forKey: .type)
         taxID = try container.decodeIfPresent(String.self, forKey: .taxID)

--- a/OmiseSwiftTests/Fixtures/api.omise.co/recipients-get.json
+++ b/OmiseSwiftTests/Fixtures/api.omise.co/recipients-get.json
@@ -48,7 +48,7 @@
       "default": true,
       "active": true,
       "name": "mobile.omise+th@gmail.com",
-      "email": "mobile.omise+th@gmail.com",
+      "email": null,
       "description": "Default recipient",
       "type": "individual",
       "tax_id": "",

--- a/OmiseSwiftTests/RecipientOperationFixtureTests.swift
+++ b/OmiseSwiftTests/RecipientOperationFixtureTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+import Omise
+
+class RecipientOperationFixtureTests: FixtureTestCase {
+
+    func testRecipientList() {
+        let expectation = self.expectation(description: "recipient list")
+        
+        let request = Recipient.list(using: testClient, params: nil) { (result) in
+            defer { expectation.fulfill() }
+            
+            switch result {
+            case let .success(recipientList):
+                XCTAssertEqual(recipientList.data.count, 2)
+            case let .failure(error):
+                XCTFail("\(error)")
+            }
+        }
+        
+        XCTAssertNotNil(request)
+        waitForExpectations(timeout: 15.0, handler: nil)
+    }
+
+}


### PR DESCRIPTION
**1. Objective**

The email of a recipient can be `null` but during the decoding a `null` value is not accepted.

**2. Description of change**

Fixed decoding of email in recipient to accept `null`.

**3. Quality assurance**

Test should pass for recipient with an email  that is `null`.

**4. Operations impact**

N/A

**5. Business impact**

N/A

**6. The priority of change**

Normal